### PR TITLE
added IntelliJ and Eclipse plugin support to Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'java'
+apply plugin: 'idea'
+apply plugin: 'eclipse'
 
 sourceCompatibility = 1.8
 


### PR DESCRIPTION
Simply run `./gradlew idea` or `./gradlew eclipse` to have Gradle generate your IDE project files.