### PR TITLE
Perform List<Integer> -> IntStream conversion in a more performant wa…

### DIFF
--- a/src/main/java/lambdas/ClosureVariables.java
+++ b/src/main/java/lambdas/ClosureVariables.java
@@ -38,7 +38,7 @@ public class ClosureVariables {
 
         // Functional, no shared mutable state
         total = nums.stream()
-                .mapToInt(Integer::valueOf)
+                .mapToInt(Integer::intValue)
                 .sum();
         System.out.printf("The total is %d%n", total);
 


### PR DESCRIPTION
…y in ClosureVariables.java

This is admittedly a nitpick but mapping the Stream<Integer> to Integer::valueOf causes autoboxing  [as described in this Stack Overflow comment](https://stackoverflow.com/questions/24633913/how-do-i-get-an-intstream-from-a-listinteger#comment38182025_24634718). Since I know this is widely viewed code by Java developers, I thought it may be helpful to change this to the more performant version using Integer::intValue in case anyone mimics it.